### PR TITLE
PR template & builds.sr.ht manifest

### DIFF
--- a/.builds/archlinux.yml
+++ b/.builds/archlinux.yml
@@ -1,0 +1,53 @@
+triggers: # NOTE: put your spam inbox here :)
+- to: Submitter Email <yourstruly+kami.builds.sr.ht@example.com>
+  action: email
+  condition: failure
+# NOTE: you can ssh into a failed build within 10 minutes:
+#     ssh -t builds@azusa.runners.sr.ht connect BUILDNUMBER
+sources: # NOTE: override submodule revisions by appending "#BRANCHNAME"
+- https://github.com/sifive/RiscvSpecFormal
+# - https://github.com/sifive/Kami#master
+# - https://github.com/sifive/ProcKami
+# - https://github.com/sifive/FpuKami
+# - https://github.com/mit-plv/bbv
+# - https://github.com/tchajed/coq-record-update
+# - https://github.com/sifive/StdLibKami.git
+# - https://github.com/riscv/riscv-tests
+image: archlinux
+packages: [coq, ghc, cabal-install, haskell-random, haskell-split, haskell-vector]
+tasks:
+- submodules: |
+    cd RiscvSpecFormal
+    git submodule foreach --quiet pwd \
+      | while IFS= read -r mod ; do
+        [ ! -d "$HOME/$(basename "$mod")" ] && continue
+        cd "$mod"
+        git fetch "$HOME/$(basename "$mod")"
+        git checkout FETCH_HEAD
+      done
+- riscvspecformal_coq: |
+    time make -C RiscvSpecFormal
+- haskell_dependencies: |
+    time cabal v1-update
+    printf "\nlibrary-vanilla: False\nshared: True\nexecutable-dynamic: True\nghc-options:\n  -dynamic\n" >> ~/.cabal/config
+    cabal v1-install hashmap bv
+- kami_hs: |
+    cd RiscvSpecFormal/Kami
+    ghc -dynamic -O1 --make ./FixLits.hs
+    time ./fixHaskell.sh .. Main.hs HaskellTarget.hs
+- riscvspecformal_hs: |
+    cd ~/RiscvSpecFormal
+    time ghc -dynamic -O1 --make -iHaskell -iKami ./Main.hs
+- riscv_toolchain: |
+    curl -s https://static.dev.sifive.com/dev-tools/riscv64-unknown-elf-gcc-8.2.0-2019.02.0-x86_64-linux-ubuntu14.tar.gz | tar -xzf -
+- riscv_tests: |
+    cd riscv-tests
+    export PATH="$PATH:$HOME/riscv64-unknown-elf-gcc-8.2.0-2019.02.0-x86_64-linux-ubuntu14/bin"
+    autoconf
+    ./configure --prefix=$HOME/riscv
+    time make install
+- haskell_test: |
+    cd ~/RiscvSpecFormal
+    export PATH="$PATH:$HOME/riscv64-unknown-elf-gcc-8.2.0-2019.02.0-x86_64-linux-ubuntu14/bin"
+    ./runElf.sh --haskell --path /home/build/riscv/share/riscv-tests/isa/rv32ui-p-simple
+    ./runElf.sh --haskell --path /home/build/riscv/share/riscv-tests/isa/rv32ui-v-simple

--- a/.builds/nix-master.yml
+++ b/.builds/nix-master.yml
@@ -1,0 +1,48 @@
+image: nixos/unstable
+packages:
+- nixpkgs.gnumake
+- nixpkgs.ghc
+- nixpkgs.haskellPackages.bv
+- nixpkgs.haskellPackages.hashmap
+- nixpkgs.haskellPackages.random
+- nixpkgs.haskellPackages.split
+- nixpkgs.haskellPackages.vector
+repositories:
+  nixpkgs: https://nixos.org/channels/nixpkgs-unstable
+sources:
+- https://github.com/sifive/RiscvSpecFormal
+tasks:
+- submodules: |
+    cd RiscvSpecFormal
+    git submodule foreach --quiet pwd \
+      | while IFS= read -r mod ; do
+        [ ! -d "$HOME/$(basename "$mod")" ] && continue
+        cd "$mod"
+        git fetch "$HOME/$(basename "$mod")"
+        git checkout FETCH_HEAD
+      done
+- coq: |
+    path=$(nix-prefetch-url --unpack 'https://github.com/coq/coq-on-cachix/tarball/master' --name source 2>&1 | tee /dev/stderr | grep -m1 '^path is' | cut -d\' -f2)
+    nix-env -if "$path" --extra-substituters "https://coq.cachix.org" --trusted-public-keys "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= coq.cachix.org-1:5QW/wwEnD+l2jvN6QRbRRsa4hBHG3QiQQ26cxu1F5tI="
+- riscvspecformal_coq: |
+    time make -C RiscvSpecFormal
+- kami_hs: |
+    cd RiscvSpecFormal/Kami
+    ghc -O1 --make ./FixLits.hs
+    time ./fixHaskell.sh .. Main.hs HaskellTarget.hs
+- riscvspecformal_hs: |
+    cd ~/RiscvSpecFormal
+    time ghc -O1 --make -iHaskell -iKami ./Main.hs
+- riscv_toolchain: |
+    curl -s https://static.dev.sifive.com/dev-tools/riscv64-unknown-elf-gcc-8.2.0-2019.02.0-x86_64-linux-ubuntu14.tar.gz | tar -xzf -
+- riscv_tests: |
+    cd riscv-tests
+    export PATH="$PATH:$HOME/riscv64-unknown-elf-gcc-8.2.0-2019.02.0-x86_64-linux-ubuntu14/bin"
+    autoconf
+    ./configure --prefix=$HOME/riscv
+    time make install
+- haskell_test: |
+    cd ~/RiscvSpecFormal
+    export PATH="$PATH:$HOME/riscv64-unknown-elf-gcc-8.2.0-2019.02.0-x86_64-linux-ubuntu14/bin"
+    ./runElf.sh --haskell --path /home/build/riscv/share/riscv-tests/isa/rv32ui-p-simple
+    ./runElf.sh --haskell --path /home/build/riscv/share/riscv-tests/isa/rv32ui-v-simple

--- a/docs/pull_request_template.md
+++ b/docs/pull_request_template.md
@@ -1,0 +1,3 @@
+Thank you for your contribution.
+
+If this change affects executable code in this repository, please [start a build](https://builds.sr.ht/submit) using [this template](https://raw.githubusercontent.com/sifive/RiscvSpecFormal/master/.builds/archlinux.yml) filled with the git source url of your branch and any submodules that need to be updated atomically with this change.


### PR DESCRIPTION
Built successfully at https://builds.sr.ht/~andres_tries_srht_github/job/82968.

Notes:

- currently only two tests are run, a fast one and a slow one. I hear running all of them would take much longer, presumably over the 1h time limit.
- `builds.sr.`ht has automatic build-on-github-PR support, but the access control granularity for it is github *organizations*, so we can't authorize it for kami only. And that limitation seems to be due to the github oauth api.
- To ssh into a failed build, your ssh key needs to be listed under the sr.ht account that submitted the build. Furthermore, the command to copy-paste is only displayed if you are also logged in as that user, though it is predictable. So I think if we had an automated solution submit builds, we could still ssh into them if we listed our keys in its account.
- I don't see any (conceptual) way to automate picking submodule versions to build for changes that pass together but either of which fails separately.